### PR TITLE
Change searchColumns list of a filter service

### DIFF
--- a/src/ng-generate/table/generators/ts-filter-service.generator.ts
+++ b/src/ng-generate/table/generators/ts-filter-service.generator.ts
@@ -411,14 +411,14 @@ export class TsFilterServiceGenerator {
             if (property.effectiveDataType?.isComplex && property.characteristic instanceof DefaultSingleEntity) {
                 const complexProps = this.options.templateHelper.getComplexProperties(property, this.options);
                 complexProps.properties.forEach((complexProp: Property) => {
-                    if (!this.options.templateHelper.isStringProperty(complexProp)) {
+                    if (!this.options.templateHelper.isStringProperty(complexProp) && !this.options.templateHelper.isMultiStringProperty(complexProp)) {
                         return;
                     }
                     stringProps.push(`'${complexProps.complexProp}.${complexProp.name}'`);
                     return;
                 });
             }
-            if (this.options.templateHelper.isStringProperty(property)) {
+            if (this.options.templateHelper.isStringProperty(property) || this.options.templateHelper.isMultiStringProperty(property)) {
                 stringProps.push(`'${property.name}'`);
             }
         });


### PR DESCRIPTION
Add MultiLanguageText properties to searchColumns list of a filter service. It provides an ability to build a filter query by MultiLanguageText properties. The approach fixes search result inconsystency when multi-language properties are excluded of the applying filters

fixes eclipse-esmf/esmf-sdk-js-schematics#10