### PR TITLE
Fix tooltip text evaluation for enum properties

### DIFF
--- a/src/ng-generate/table/generators/ts-pipe.generator.ts
+++ b/src/ng-generate/table/generators/ts-pipe.generator.ts
@@ -22,9 +22,12 @@ export class TsPipeGenerator {
         @Pipe({name: 'showDescription'})
         export class ShowDescriptionPipe implements PipeTransform {
             transform(value: any, getByValueFn: any, onlyDesc?: boolean): any {
-                return onlyDesc
-                    ? \`\${getByValueFn(value.toString())?.description}\` || ''
-                    : \`\${value} - \${getByValueFn(value.toString())?.description}\` || '';
+                value = value?.toString();
+
+                const resultParts: string[] = value && !onlyDesc ? [value] : [];
+                resultParts.push(getByValueFn(value)?.description);
+
+                return resultParts.join(' - ');
             }
         }
         `;


### PR DESCRIPTION
SDK table fails to display data when an enum property value is `null`. So, I added a condition to check `null` and `undefined` values for enum table properties. In addition to that I added `ngIf` to the copy to clipboard button to not show the button when an enum table property is empty. 
On top of that, ShowDescriptionPipe has an empty value check to be like a final checkpoint to not throw js-error and return empty string.

fixes eclipse-esmf/esmf-sdk-js-schematics#14