### PR TITLE
Add HighlightDirective to highlight search filter

### DIFF
--- a/src/ng-generate/table/generators/html.generator.ts
+++ b/src/ng-generate/table/generators/html.generator.ts
@@ -70,8 +70,8 @@ export class HtmlGenerator {
                                           (removed)="removeFilter(filter)"
                                   >
                                       <div data-test="chip-text" class="chip-text"
-                                           matTooltip="{{ filter.prop }}: {{ filter.label }}">
-                                           <b>{{filter.prop}}</b>: {{ filter.label }}</div>
+                                           matTooltip="{{ filter.filterValue }}: {{ filter.label }}">
+                                           <b>{{filter.filterValue}}</b>: {{ filter.label }}</div>
                                       <button *ngIf="filter.removable" matChipRemove data-test="mat-chip-remove">
                                           <mat-icon class="material-icons" data-test="remove-chip">cancel</mat-icon>
                                       </button>
@@ -148,17 +148,13 @@ export class HtmlGenerator {
         
         ${this.hasSearchBar ? `
             <!-- Highlighting search values -->
-            <ng-template #normal let-value="value">{{ value === null ? '-' : value }}</ng-template>
-            <ng-template #searchedWordExists let-value="value">
-              <ng-container *ngFor="let letter of value.toString().split(''); let i = index">
-                <ng-container [ngTemplateOutlet]="shouldHighlight(value, letter) ? highlight : notHighlighted"
-                              [ngTemplateOutletContext]="{ $implicit: letter }"></ng-container>
-              </ng-container>
-            </ng-template>
-            <ng-template #highlight let-letter>
-              <mark [style.background-color]="highlightConfig?.color">{{ letter }}</mark>
-            </ng-template>
-            <ng-template #notHighlighted let-letter>{{ letter }}</ng-template>` : ''}
+            <ng-template #highlightCell let-value="value">
+                <span [highlight]="highlightString"
+                      [highlightSource]="value"
+                      [highlightColor]="highlightConfig?.color">
+                {{ value === null ? '-' : value }}
+            </span>  
+            </ng-template>` : ''}
         `;
     }
 
@@ -346,7 +342,7 @@ export class HtmlGenerator {
             mat-cell *matCellDef="let row" ${this.templateHelper.isNumberProperty(property) ? `class="table-cell-number"` : ''}>
             ${this.hasSearchBar ? `
                  <ng-container
-                  [ngTemplateOutlet]="highlightConfig?.selected && ((${cellContent}) | searchString: highlightString) ? searchedWordExists : normal"
+                  [ngTemplateOutlet]="highlightCell"
                   [ngTemplateOutletContext]="{ value: ${cellContent} }"></ng-container>` : `{{${cellContent}}}`}
             
               <button data-test="copy-to-clipboard-button"

--- a/src/ng-generate/table/generators/ts-component.generator.ts
+++ b/src/ng-generate/table/generators/ts-component.generator.ts
@@ -182,12 +182,6 @@ export class TsComponentGenerator {
             
             setConfiguration(configs: Array<Config>): void {
               this.configs = [...configs];
-            }
-            
-            shouldHighlight(name: string, letter: string): boolean {
-              const highlightLetters = [...new Set(this.highlightString.join().split(''))].join();
-              const index = name.toString().indexOf(letter);
-              return index !== -1 && highlightLetters.includes(name.toString()[index]);
             }`
                     : ''
             }

--- a/src/ng-generate/table/generators/ts-directive.generator.ts
+++ b/src/ng-generate/table/generators/ts-directive.generator.ts
@@ -362,7 +362,7 @@ export class TsDirectiveGenerator {
             }
 
             private canHighlightText(): boolean {
-                return this.el?.nativeElement && this._highlight.length > 0 && typeof this.highlightSource === 'string' && this.highlightSource.length > 0 && !!this._color;
+                return this.el?.nativeElement && this._highlight && typeof this.highlightSource === 'string' && this.highlightSource.length > 0 && !!this._color;
             }
 
             private calcRangesToReplace(): HighlightRange[] {

--- a/src/ng-generate/table/generators/ts-directive.generator.ts
+++ b/src/ng-generate/table/generators/ts-directive.generator.ts
@@ -294,144 +294,149 @@ export class TsDirectiveGenerator {
     static generateHighlightDirective(options: Schema): string {
         return `
         /** ${options.templateHelper.getGenerationDisclaimerText()} **/
-        import {
-            Directive,
-            ElementRef,
-            Input,
-            OnChanges,
-            OnInit,
-            SecurityContext,
-            SimpleChange,
-            SimpleChanges
-          } from '@angular/core';
-          import { DomSanitizer } from '@angular/platform-browser';
-           
-          interface HighlightSimpleChanges extends SimpleChanges {
+        import {Directive, ElementRef, Input, OnChanges, OnInit, SecurityContext, SimpleChange, SimpleChanges} from '@angular/core';
+        import {DomSanitizer} from '@angular/platform-browser';
+
+        interface HighlightSimpleChanges extends SimpleChanges {
             highlight: SimpleChange;
             caseSensitive: SimpleChange;
-          }
-          
-          interface HighlightRange {
+        }
+
+        interface HighlightRange {
             from: number;
             to: number;
-          }
-          
-            @Directive({
-              selector: '[highlight]'
-            })
-            export class HighlightDirective implements OnChanges, OnInit {
-              @Input() highlightSource: string | null = null;
-              @Input() set highlight(value: string | string[]) {
+        }
+
+        const threeDigitsRegExp = new RegExp("^#?\\d{3}$");
+        const sixDigitsRegExp = new RegExp("^#?\\d{6}$");
+
+        @Directive({
+            selector: '[highlight]',
+        })
+        export class HighlightDirective implements OnChanges, OnInit {
+            @Input() highlightSource: string | null = null;
+            @Input() set highlight(value: string | string[]) {
                 this._highlight = Array.isArray(value) ? value : [value];
-              }
-              
-              @Input('highlightColor') highlightColor: string | undefined = undefined;
-              
-              @Input() set caseSensitive(value: boolean) {
-                  this.regExpFlags = value ? 'g' : 'gi'
-              };
-            
-              private regExpFlags = 'gi';
-              private _highlight: string[] = [];
-          
-              constructor(private el: ElementRef, private sanitizer: DomSanitizer) {}
-            
-              ngOnChanges(changes: HighlightSimpleChanges) {
-                if ((changes.highlight && !changes.highlight.firstChange) || (changes.caseSensitive && !changes.caseSensitive.firstChange)) {
-                  this.transformText();
-                }
-              }
-          
-              ngOnInit(): void {
-                this.transformText();
-              }
-          
-              private transformText(): void {
-                if (this.el?.nativeElement) {
-                    if (this._highlight.length > 0 && this.highlightSource && !!this.highlightColor) {
-                      
-                      const allRanges = this.calcRangesToReplace();
-                      const rangesToHighlight = this.mergeRangeIntersections(allRanges);
-                      const content = this.sanitizer.sanitize(SecurityContext.STYLE, this.replaceHighlights(rangesToHighlight));
-          
-                      if (content?.length) {
-                        (this.el.nativeElement as HTMLElement).innerHTML = content;
-                      }
+            }
+
+            @Input() set highlightColor(value: string | undefined) {
+                if (value) {
+                    if (value.match(threeDigitsRegExp) || value.match(sixDigitsRegExp)) {
+                        this._color = value.padStart(value.length + 1, '#');
+                    } else {
+                        this._color = value;
                     }
                 }
-              }
-          
-              private calcRangesToReplace(): HighlightRange[] {
+            }
+
+            @Input() set caseSensitive(value: boolean) {
+                this.regExpFlags = value ? 'g' : 'gi';
+            }
+
+            private regExpFlags = 'gi';
+            private _highlight: string[] = [];
+            private _color: string | undefined = undefined;
+
+            constructor(private el: ElementRef, private sanitizer: DomSanitizer) {}
+
+            ngOnChanges(changes: HighlightSimpleChanges) {
+                if ((changes.highlight && !changes.highlight.firstChange) || (changes.caseSensitive && !changes.caseSensitive.firstChange)) {
+                    this.transformText();
+                }
+            }
+
+            ngOnInit(): void {
+                this.transformText();
+            }
+
+            private transformText(): void {
+                if (this.canHighlightText()) {
+                    const allRanges = this.calcRangesToReplace();
+                    const rangesToHighlight = this.mergeRangeIntersections(allRanges);
+                    const content = this.sanitizer.sanitize(SecurityContext.STYLE, this.replaceHighlights(rangesToHighlight));
+
+                    if (content?.length) {
+                        (this.el.nativeElement as HTMLElement).innerHTML = content;
+                    }
+                }
+            }
+
+            private canHighlightText(): boolean {
+                return this.el?.nativeElement && this._highlight.length > 0 && typeof this.highlightSource === 'string' && this.highlightSource.length > 0 && !!this._color;
+            }
+
+            private calcRangesToReplace(): HighlightRange[] {
                 return this._highlight
-                        .map(highlightString => {
-                          const matches = this.highlightSource?.toLowerCase().matchAll(new RegExp(highlightString.toLowerCase(), this.regExpFlags));
-                          if(!matches) {
-                            return [];  
-                          }
-          
-                          const len = highlightString.length;
-          
-                          const matchIndexes = [...matches]
+                    .map(highlightString => {
+                        const matches = this.highlightSource?.matchAll(new RegExp(highlightString.toLowerCase(), this.regExpFlags));
+                        if (!matches) {
+                            return [];
+                        }
+
+                        const len = highlightString.length;
+
+                        const matchIndexes = [...matches]
                             .filter((a: RegExpMatchArray) => a && a.index !== undefined)
                             .map<HighlightRange>(a => ({from: a.index!, to: a.index! + len}));
-          
-                          return matchIndexes;
-                        })
-                        .filter(match => match.length > 0)
-                        .flat()
-                        .sort((a, b) => a.from - b.from);
-              }
-          
-              private mergeRangeIntersections(allRanges: HighlightRange[]): HighlightRange[] {
+
+                        return matchIndexes;
+                    })
+                    .filter(match => match.length > 0)
+                    .flat()
+                    .sort((a, b) => a.from - b.from);
+            }
+
+            private mergeRangeIntersections(allRanges: HighlightRange[]): HighlightRange[] {
                 if (allRanges.length === 0) {
-                  return [];
+                    return [];
                 }
-          
+
                 const rangesToHighlight = [allRanges[0]];
-               
-                allRanges.forEach((range) => {
-                  const currentRange = rangesToHighlight[rangesToHighlight.length-1];
-          
-                  if(range.from <= currentRange.from) {
-                    currentRange.from = range.from;
-          
-                    if(range.to > currentRange.to) {
-                      currentRange.to = range.to;
+
+                allRanges.forEach(range => {
+                    const currentRange = rangesToHighlight[rangesToHighlight.length - 1];
+
+                    if (range.from <= currentRange.from) {
+                        currentRange.from = range.from;
+
+                        if (range.to > currentRange.to) {
+                            currentRange.to = range.to;
+                        }
+                    } else if (range.from <= currentRange.to && range.to >= currentRange.to) {
+                        currentRange.to = range.to;
+                    } else {
+                        rangesToHighlight.push(range);
                     }
-                  } else if(range.from <= currentRange.to && range.to >= currentRange.to) {
-                    currentRange.to = range.to;
-                  } else {
-                    rangesToHighlight.push(range);
-                  }
                 });
-          
+
                 return rangesToHighlight;
-              }
-          
-              private replaceHighlights(rangesToHighlight: HighlightRange[]): string {
-                if(!this.highlightSource?.length || rangesToHighlight.length === 0) {
-                  return '';
+            }
+
+            private replaceHighlights(rangesToHighlight: HighlightRange[]): string {
+                if (!this.highlightSource?.length || rangesToHighlight.length === 0) {
+                    return '';
                 }
-          
+
                 const resultStringParts: string[] = [];
                 let index = 0;
-                
+
                 rangesToHighlight.forEach(({from, to}) => {
-                  if (from > index) {
-                    resultStringParts.push(this.highlightSource!.substring(index, from));
-                  }
-          
-                  const strPart = this.highlightSource!.substring(from, to);
-                  resultStringParts.push('<mark style="background-color: ' + this.highlightColor!.padStart(7,'#') + ';">'+ strPart + '</mark>');
-                  index = to;
+                    if (from > index) {
+                        resultStringParts.push(this.highlightSource!.substring(index, from));
+                    }
+
+                    const strPart = this.highlightSource!.substring(from, to);
+                    resultStringParts.push('<mark style="background-color: ' + this._color + ';">' + strPart + '</mark>');
+                    index = to;
                 });
-          
+
                 if (index < this.highlightSource!.length) {
-                  resultStringParts.push(this.highlightSource!.substring(index));
+                    resultStringParts.push(this.highlightSource!.substring(index));
                 }
-          
+
                 return resultStringParts.join('');
-              }
-            }`;
+            }
+        }
+`;
     }
 }

--- a/src/ng-generate/table/generators/ts-pipe.generator.ts
+++ b/src/ng-generate/table/generators/ts-pipe.generator.ts
@@ -32,30 +32,4 @@ export class TsPipeGenerator {
         }
         `;
     }
-
-    static generateSearchStringPipe(options: Schema): string {
-        return `
-        /** ${options.templateHelper.getGenerationDisclaimerText()} **/
-        import {Pipe, PipeTransform} from '@angular/core';
-        import {FormControl} from "@angular/forms";
-        @Pipe({
-          name: 'searchString',
-          pure: true
-        })
-        export class SearchStringPipe implements PipeTransform {
-          transform(value: any, searchString: string[]): boolean {
-            if (typeof value === 'boolean') {
-              value = value.toString();
-            }
-            if (value.constructor.name === 'Date') {
-              value = value.toLocaleString();
-            }
-            if (typeof value !== 'string') {
-              return false;
-            }
-            return searchString.length !== 0 && searchString.some(term => value?.includes(term));
-          }
-        }
-        `;
-    }
 }

--- a/src/ng-generate/table/generators/ts.generator.ts
+++ b/src/ng-generate/table/generators/ts.generator.ts
@@ -59,8 +59,8 @@ export class TsGenerator {
         return TsPipeGenerator.generateShowDescriptionPipe(this.options);
     }
 
-    generateSearchStringPipe(): string {
-        return TsPipeGenerator.generateSearchStringPipe(this.options);
+    generateHighlightDirective(): string {
+        return TsDirectiveGenerator.generateHighlightDirective(this.options);
     }
 
     generateHorizontalOverflowDirective(): string {

--- a/src/ng-generate/table/index.ts
+++ b/src/ng-generate/table/index.ts
@@ -244,7 +244,7 @@ export function generateTable(options: Schema): Rule {
         generateResizeDirective(options),
         generateValidateInputDirective(options),
         generateShowDescriptionPipe(options),
-        generateSearchStringPipe(options),
+        generateHighlightDirective(options),
         generateHorizontalOverflowDirective(options),
         generateStorageService(options),
         formatGeneratedFiles(
@@ -524,6 +524,20 @@ function generateValidateInputDirective(options: Schema): Rule {
     };
 }
 
+function generateHighlightDirective(options: Schema): Rule {
+    return (tree: Tree, _context: SchematicContext) => {
+        if (options.enabledCommandBarFunctions.includes('addSearchBar')) {
+            const directiveName = 'HighlightDirective';
+            const directiveContent = options.tsGenerator.generateHighlightDirective();
+            const directivePath = 'src/app/shared/directives/highlight.directive';
+            createOrOverwrite(tree, `${directivePath}.ts`, options.overwrite, directiveContent);
+            addToDeclarationsArray(options, tree, directiveName, directivePath, options.templateHelper.getSharedModulePath()).then();
+            addToExportsArray(options, tree, directiveName, directivePath, options.templateHelper.getSharedModulePath()).then();
+            return tree;
+        }
+    };
+}
+
 function generateShowDescriptionPipe(options: Schema): Rule {
     return (tree: Tree, _context: SchematicContext): Tree => {
         const pipeName = 'ShowDescriptionPipe';
@@ -533,20 +547,6 @@ function generateShowDescriptionPipe(options: Schema): Rule {
         addToDeclarationsArray(options, tree, pipeName, pipePath, options.templateHelper.getSharedModulePath()).then();
         addToExportsArray(options, tree, pipeName, pipePath, options.templateHelper.getSharedModulePath()).then();
         return tree;
-    };
-}
-
-function generateSearchStringPipe(options: Schema): Rule {
-    return (tree: Tree, context: SchematicContext) => {
-        if (options.enabledCommandBarFunctions.includes('addSearchBar')) {
-            const pipeName = 'SearchStringPipe';
-            const pipeContent = options.tsGenerator.generateSearchStringPipe();
-            const pipePath = 'src/app/shared/pipes/search-string.pipe';
-            createOrOverwrite(tree, `${pipePath}.ts`, options.overwrite, pipeContent);
-            addToDeclarationsArray(options, tree, pipeName, pipePath, options.templateHelper.getSharedModulePath()).then();
-            addToExportsArray(options, tree, pipeName, pipePath, options.templateHelper.getSharedModulePath()).then();
-            return tree;
-        }
     };
 }
 


### PR DESCRIPTION
The library was using SearchStringPipe to detect a highlighted test at table columns with 3 ng-templates and a method at a table component itself. Besides the described issue #18, using pipe in a way it is not supposed, the approach breaks the single responsibility principle.
To fix the issue and improve the table.component architecture I created HighlightDirective that replaced SearchStringPipe and incapsulate all the highlight logic.

fixes #18