### PR TITLE
Fix table columns resizing functionality

### DIFF
--- a/src/ng-generate/components/shared/generators/styles/general/files/__name@dasherize__.component.scss.template
+++ b/src/ng-generate/components/shared/generators/styles/general/files/__name@dasherize__.component.scss.template
@@ -16,7 +16,7 @@ $gray-300: #e0e0e0;
     overflow-y: auto;
 
     .full-width-table {
-      width: 100%;
+      min-width: 100%;
 
       .mat-mdc-row:not([data-test='no-data-table-row']):not(.selected-row):hover {
         background: $gray-100;
@@ -135,6 +135,22 @@ $gray-300: #e0e0e0;
       display: flex;
       overflow: hidden;
       scroll-behavior: smooth;
+    }
+  }
+}
+
+.resizing {
+  .js-sdk-component-container {
+    // Ignore columns with active sorting
+    .mat-sort-header[aria-sort]:not([aria-sort='ascending']):not([aria-sort='descending']) {
+      .mat-sort-header-container::after {
+        // Compensate the empty space when sorting indicator is hidden for a resizable column
+        content: '';
+        display: block;
+        height: 100%;
+        min-width: 18px;
+        max-width: 18px;
+      }
     }
   }
 }

--- a/src/ng-generate/components/shared/methods/generation/extended-table.html.template
+++ b/src/ng-generate/components/shared/methods/generation/extended-table.html.template
@@ -47,14 +47,9 @@
 
                 <!-- <%= cellPropertyPath %> Column -->
                 <ng-container data-test="table-column" matColumnDef="<%= cellPropertyPath %>">
-                    <th data-test="table-header" mat-header-cell *matHeaderCellDef
-                        mat-sort-header="<%= cellPropertyPath %>"
-
+                    <th data-test="table-header" mat-header-cell *matHeaderCellDef mat-sort-header="<%= cellPropertyPath %>"
                         <%= options.templateHelper.isNumberProperty(value.property) ? `class="table-header-number"` : '' %>
-
-                        <% if (tableColumValuesFunc.length - 1 > value.index) { %>
-                            [resizeColumn]="true" [index]="<%= value.index %>" (dragging)='dragging = $event'
-                        <% } %>
+                        [resizeColumn]="true" [index]="<%= value.index %>" (dragging)='dragging = $event'
                     >
                         <span [matTooltip]=" '<%= propertyLocaleKeyPath %>.description' | transloco"
                               [matTooltipDisabled]="headerTooltipsOff"
@@ -118,11 +113,11 @@
                 <th style="text-align: right;justify-content: flex-end;" data-test="columns-menu-button-header" mat-header-cell *matHeaderCellDef>
                     <button data-test="mat-table-menu-button"
                         mat-icon-button
-                        [matMenuTriggerFor]="columnMenu"
-                        (menuOpened)="initOpenedColumnMenuDialog()"
                         aria-label="Menu for the table"
                         class="mat-table-menu-button"
-                        [matTooltip]="'tableActions.openColumnsMenu' | transloco">
+                        [matMenuTriggerFor]="columnMenu"
+                        [matTooltip]="'tableActions.openColumnsMenu' | transloco"
+                        (menuOpened)="initOpenedColumnMenuDialog()">
                             <mat-icon data-test="mat-table-menu-icon" class="material-icons">settings</mat-icon>
                     </button>
                 </th>

--- a/src/ng-generate/components/shared/methods/generation/simple-table.html.template
+++ b/src/ng-generate/components/shared/methods/generation/simple-table.html.template
@@ -62,10 +62,7 @@
                 <ng-container data-test="table-column" matColumnDef="<%= cellPropertyPath %>">
                     <th data-test="table-header" mat-header-cell *matHeaderCellDef
                         <%= options.templateHelper.isNumberProperty(value.property) ? `class="table-header-number"` : '' %>
-
-                        <% if (options.tableColumValues(options.listProps, options).length - 1 > value.index) { %>
-                            [resizeColumn]="true" [index]="<%= value.index %>" (dragging)='dragging = $event'
-                        <% } %>
+                        [resizeColumn]="true" [index]="<%= value.index %>" (dragging)='dragging = $event'
                     >
                         <span [matTooltip]=" '<%= propertyLocaleKeyPath %>.description' | transloco"
                               [matTooltipDisabled]="headerTooltipsOff"

--- a/src/ng-generate/components/table/generators/directives/resize/files/__name@dasherize__.directive.ts.template
+++ b/src/ng-generate/components/table/generators/directives/resize/files/__name@dasherize__.directive.ts.template
@@ -8,6 +8,8 @@ import {DOCUMENT} from '@angular/common';
 export class <%= classify(name) %>Directive implements OnInit {
     @Input('resizeColumn') resizable: boolean = false;
     @Input() index: number = 0;
+    @Input() minWidth: number = 50;
+    @Input() initialWidth: number = 200;
 
     @Output() dragging = new EventEmitter<any>();
 
@@ -16,7 +18,6 @@ export class <%= classify(name) %>Directive implements OnInit {
     private readonly column!: HTMLElement;
     private table!: HTMLElement;
     private pressed!: boolean;
-    private tableCells!: HTMLElement[];
     private handle!: HTMLElement;
 
     private mouseMoveListener!: () => void;
@@ -46,6 +47,7 @@ export class <%= classify(name) %>Directive implements OnInit {
         const row = this.renderer.parentNode(this.column);
         const thead = this.renderer.parentNode(row);
         this.table = this.renderer.parentNode(thead);
+        this.renderer.setStyle(this.column, 'min-width', `${this.initialWidth}px`);
     }
 
     setListeners(): void {
@@ -69,35 +71,27 @@ export class <%= classify(name) %>Directive implements OnInit {
         this.mouseLeaveListener();
         this.dragging.emit(true);
         this.startX = event.pageX;
-        this.startWidth = this.column.offsetWidth;
+        this.startWidth = this.column.getBoundingClientRect().width;
         this.renderer.addClass(this.document.body, 'resizing');
-        this.tableCells = Array.from(this.table.querySelectorAll('.mat-row')).map((row: any) =>
-            row.querySelectorAll('.mat-cell').item(this.index)
-        );
         this.mouseMoveListener = this.renderer.listen(this.table, 'mousemove', this.onMouseMove);
         this.mouseUpListener = this.renderer.listen('document', 'mouseup', this.onMouseUp);
     };
 
     onMouseMove = (event: MouseEvent): void => {
-        const offset = 35;
         if (this.pressed && event.buttons) {
             // Calculate width of column
-            let width = this.startWidth + (event.pageX - this.startX - offset);
+            const distance = event.pageX - this.startX;
+            const targetWidth = this.startWidth + distance;
+            const width = targetWidth >= this.minWidth ? targetWidth : this.minWidth;
 
-            // Set table header width
+            // Set column width explicitly (cells are getting resized automatically)
+            this.renderer.setStyle(this.column, 'min-width', `${width}px`);
             this.renderer.setStyle(this.column, 'width', `${width}px`);
-
-            // Set table cells width
-            for (const cell of this.tableCells) {
-                this.renderer.setStyle(cell, 'width', `${width}px`);
-            }
         }
     };
 
     onMouseUp = (): void => {
         if (this.pressed) {
-            this.renderer.removeClass(this.document.body, 'resizing');
-            this.renderer.setStyle(this.handle, 'opacity', '0');
             this.mouseMoveListener();
             this.mouseUpListener();
             this.setListeners();
@@ -108,6 +102,8 @@ export class <%= classify(name) %>Directive implements OnInit {
             // worked. If you have another idea, please feel free to change it.
             setTimeout((): void => {
                 this.dragging.emit(false);
+                this.renderer.removeClass(this.document.body, 'resizing');
+                this.renderer.setStyle(this.handle, 'opacity', '0');
             }, 0);
         }
     };

--- a/src/ng-generate/components/table/generators/directives/resize/files/__name@dasherize__.directive.ts.template
+++ b/src/ng-generate/components/table/generators/directives/resize/files/__name@dasherize__.directive.ts.template
@@ -71,7 +71,7 @@ export class <%= classify(name) %>Directive implements OnInit {
         this.mouseLeaveListener();
         this.dragging.emit(true);
         this.startX = event.pageX;
-        this.startWidth = this.column.getBoundingClientRect().width;
+        this.startWidth = this.column.offsetWidth;
         this.renderer.addClass(this.document.body, 'resizing');
         this.mouseMoveListener = this.renderer.listen(this.table, 'mousemove', this.onMouseMove);
         this.mouseUpListener = this.renderer.listen('document', 'mouseup', this.onMouseUp);


### PR DESCRIPTION
The PR adds a possibility to stretch table columns wider than the initial table size allows to do, which also fixes a bug with "unresizable columns" when they do not fit its container width. As a result, the updated behaviour provides to the user a more robust control over columns sizing regardless of the layout.