### PR TITLE
Fix problem that table update finished are called twice

### DIFF
--- a/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.ts.template
+++ b/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.ts.template
@@ -504,9 +504,9 @@ export class <%= classify(name) %>Component implements OnInit, AfterViewInit, Af
           <% if (options.addRowCheckboxes) { %>
               this.trimSelectionToCurrentPage();
           <% } %>
-      <% } %>
 
-      this.tableUpdateFinishedEvent.emit();
+          this.tableUpdateFinishedEvent.emit();
+      <% } %>
     }
 
     <% if (!options.enableRemoteDataHandling) { %>


### PR DESCRIPTION
See https://github.com/eclipse-esmf/esmf-sdk-js-schematics/issues/80

Table update finished event will called only when async request is finished.

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes #(number of issue in GitHub)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
