### PR TITLE
Add resize functionality to custom columns

### DIFF
--- a/src/ng-generate/components/shared/methods/generation/extended-table.html.template
+++ b/src/ng-generate/components/shared/methods/generation/extended-table.html.template
@@ -87,19 +87,21 @@
             <% } %>
 
             <% if(options.customColumns && options.customColumns.length > 0) { %>
-                <% for(let columnName of options.customColumns) { %>
+                <% for(let [index, columnName] of options.customColumns.entries()) { %>
+                    <% let customColumnIndex = tableColumValuesFunc.length + index + 1; %>
                     <!-- <%= columnName %> Column -->
                     <ng-container data-test="custom-column-container" matColumnDef="<%= columnName %>">
                         <% if(options.enableVersionSupport) { %>
-                            <th data-test="custom-column-header" mat-header-cell *matHeaderCellDef mat-sort-header>
-                                {{'<%= options.selectedModelTypeName.toLowerCase() %>.v<%= options.formatedAspectModelVersion %>.customColumn.<%= columnName %>' | transloco}}
+                            <th data-test="custom-column-header" mat-header-cell *matHeaderCellDef mat-sort-header
+                                [resizeColumn]="true" [index]="<%= customColumnIndex %>" (dragging)='dragging = $event'>
+                                {{'<%= options.selectedModelTypeName.toLowerCase() %>.v<%= options.formatedAspectModelVersion %>.customColumn.<%= columnName %>' | transloco }}
                             </th>
                         <% } else { %>
-                            <th data-test="custom-column-header" mat-header-cell *matHeaderCellDef mat-sort-header>
+                            <th data-test="custom-column-header" mat-header-cell *matHeaderCellDef mat-sort-header
+                                [resizeColumn]="true" [index]="<%= customColumnIndex %>" (dragging)='dragging = $event'>
                                 {{ '<%= options.selectedModelTypeName.toLowerCase() %>.customColumn.<%= columnName %>' | transloco }}
                             </th>
                         <% } %>
-
                         <td data-test="custom-column-cell" mat-cell *matCellDef="let row">
                             <ng-container data-test="custom-column-container" *ngTemplateOutlet="<%= camelize(columnName) %>Template; context:{aspect:row}"></ng-container>
                         </td>


### PR DESCRIPTION
## Description

Columns resize functionality is applied to a regular column, and is not applied to custom columns. The issue is resolved with the bug fix.

Fixes #91 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional notes:
