### PR TITLE
Add paginator config provider

### DIFF
--- a/src/ng-generate/components/shared/generators/modules/translation/module-files/__name@dasherize__.module.ts.template
+++ b/src/ng-generate/components/shared/generators/modules/translation/module-files/__name@dasherize__.module.ts.template
@@ -4,6 +4,7 @@ import {isDevMode, NgModule} from '@angular/core';
 import {environment} from "../../environments/environment";
 import {provideTransloco, TranslocoModule} from '@ngneat/transloco';
 import {TransLocoHttpLoader} from './trans-loco-http-loader';
+import {PaginatorSelectConfigProvider} from './services/paginator-select-config.provider';
 
 export const baseUrl = (environment as any).baseUrl || '';
 
@@ -11,7 +12,8 @@ export const baseUrl = (environment as any).baseUrl || '';
     imports: [TranslocoModule],
     exports: [TranslocoModule],
     providers: [
-        <%= providerInfo %>
+        <%= providerInfo %>,
+        PaginatorSelectConfigProvider
     ],
     })
 export class <%= classify(name) %>Module {}

--- a/src/ng-generate/components/shared/generators/services/index.ts
+++ b/src/ng-generate/components/shared/generators/services/index.ts
@@ -14,3 +14,4 @@
 export * from './custom/index';
 export * from './filter/index';
 export * from './general/index';
+export * from './paginator-select-config/index';

--- a/src/ng-generate/components/shared/generators/services/paginator-select-config/files/paginator-select-config.provider.ts.template
+++ b/src/ng-generate/components/shared/generators/services/paginator-select-config/files/paginator-select-config.provider.ts.template
@@ -1,0 +1,15 @@
+/** <%= options.generationDisclaimerText %> **/
+import {InjectionToken, Optional, Provider, SkipSelf} from '@angular/core';
+import {MatPaginatorSelectConfig} from '@angular/material/paginator';
+
+export const PaginatorSelectConfigInjector = new InjectionToken<MatPaginatorSelectConfig>('PaginatorSelectConfig');
+
+export const PaginatorSelectConfigProvider: Provider = {
+    provide: PaginatorSelectConfigInjector,
+    useFactory: (customConfig?: MatPaginatorSelectConfig) => {
+        return (
+            customConfig || { disableOptionCentering: true }
+        );
+    },
+    deps: [[new Optional(), new SkipSelf(), PaginatorSelectConfigInjector]]
+};

--- a/src/ng-generate/components/shared/generators/services/paginator-select-config/index.ts
+++ b/src/ng-generate/components/shared/generators/services/paginator-select-config/index.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for
+ * additional information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import {apply, applyTemplates, MergeStrategy, mergeWith, move, Rule, SchematicContext, Tree, url} from '@angular-devkit/schematics';
+import {strings} from '@angular-devkit/core';
+
+export function generatePaginatorSelectConfigProvider(options: any): Rule {
+    return (tree: Tree, _context: SchematicContext) => {
+        return mergeWith(
+            apply(url('../shared/generators/services/paginator-select-config/files'), [
+                applyTemplates({
+                    classify: strings.classify,
+                    dasherize: strings.dasherize,
+                    options: options,
+                }),
+                move('src/app/shared/services')
+            ]),
+            options.overwrite ? MergeStrategy.Overwrite : MergeStrategy.Error
+        );
+    };
+}

--- a/src/ng-generate/components/shared/methods/generation/extended-table.html.template
+++ b/src/ng-generate/components/shared/methods/generation/extended-table.html.template
@@ -148,6 +148,7 @@
                    [pageIndex]="0"
                    [pageSize]="pageSize"
                    [pageSizeOptions]="pageSizeOptions"
+                   [selectConfig]="paginatorSelectConfig"
                    [showFirstLastButtons]="showFirstLastButtons"
                    (page)="pageChange()">
     </mat-paginator>

--- a/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.ts.template
+++ b/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.ts.template
@@ -18,7 +18,7 @@ import {
     <% if (options.enableRemoteDataHandling || options.hasSearchBar) { %>OnDestroy,<% } %>
     <% if (options.changeDetection) { %>ChangeDetectionStrategy,<% } %>
 } from '@angular/core';
-import { MatPaginator } from '@angular/material/paginator';
+import { MatPaginator, MatPaginatorSelectConfig } from '@angular/material/paginator';
 import { MatSort, SortDirection } from '@angular/material/sort';
 import { MatTable } from '@angular/material/table';
 
@@ -56,6 +56,7 @@ import {<%= classify(name) %>DataSource} from './<%= dasherize(name) %>-datasour
 import {DomSanitizer} from '@angular/platform-browser';
 import {SelectionModel} from '@angular/cdk/collections';
 import { TranslocoService } from '@ngneat/transloco';
+import {PaginatorSelectConfigInjector} from "<% if (options.enableVersionSupport) { %>../<% } %>../../services/paginator-select-config.provider";
 import {JSSdkLocalStorageService} from "<% if (options.enableVersionSupport) { %>../<% } %>../../services/storage.service";
 import {<%= classify(name) %>ColumnMenuComponent} from './<%= dasherize(name) %>-column-menu.component';
 

--- a/src/ng-generate/components/table/generators/components/table/index.ts
+++ b/src/ng-generate/components/table/generators/components/table/index.ts
@@ -167,6 +167,7 @@ function commonImports(): string {
             public dialog: MatDialog,
             private clipboard: Clipboard,
             private storageService: JSSdkLocalStorageService,
+            @Inject(PaginatorSelectConfigInjector) public paginatorSelectConfig: MatPaginatorSelectConfig,
             ${sharedOptions.hasFilters ? `public filterService: ${sharedOptions.filterServiceName},` : ''}
             ${
                 sharedOptions.isDateQuickFilter

--- a/src/ng-generate/components/table/index.ts
+++ b/src/ng-generate/components/table/index.ts
@@ -38,6 +38,7 @@ import {generateTableComponent} from './generators/components/table/index';
 import {generateDataSource} from './generators/data-source/index';
 import {TableSchema} from './schema';
 import {generateExportTableDialog} from './generators/components/export-dialog/index';
+import {generatePaginatorSelectConfigProvider} from '../shared/generators';
 
 export default function (tableSchema: TableSchema): Rule {
     return (tree: Tree, context: SchematicContext) => {
@@ -71,6 +72,7 @@ function tableSpecificGeneration(): Array<Rule> {
         generateColumnMenu(options),
         generateConfigMenu(options),
         generateExportTableDialog(options),
+        generatePaginatorSelectConfigProvider(options),
         generateResizeDirective(options),
         generateHighlightDirective(options),
     ];


### PR DESCRIPTION
## Description

The PR introduces TablePaginatorSelectConfig Injection Token to provide an ability for table generator consumers specify a table paginator select position and styles.
The schematic table currently has the default select component configuration that can be overridden by `PaginatorSelectConfigInjector` token

Fixes #73

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional notes:
