### PR TITLE
Move custom imports to the bottom of components styles file

### DIFF
--- a/src/ng-generate/components/shared/generators/styles/general/files/__name@dasherize__.component.scss.template
+++ b/src/ng-generate/components/shared/generators/styles/general/files/__name@dasherize__.component.scss.template
@@ -1,7 +1,5 @@
 /** <%= options.generationDisclaimerText %> **/
 
-<%= customStyleImports %>
-
 $gray-100: #f5f5f5;
 $gray-300: #e0e0e0;
 
@@ -270,3 +268,5 @@ $gray-300: #e0e0e0;
 .mat-mdc-menu-panel {
   max-width: max-content !important;
 }
+
+<%= customStyleImports %>


### PR DESCRIPTION
## Description

Move importing custom schematic components styles to the bottom of global.componsnts.scss file. The change is required to follow CSS cascade principle.

Fixes #71 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
