### PR TITLE
Reset all filters on destroying a table or a card component

### DIFF
--- a/src/ng-generate/components/card/generators/components/card/files/__name@dasherize__.component.ts.template
+++ b/src/ng-generate/components/card/generators/components/card/files/__name@dasherize__.component.ts.template
@@ -369,8 +369,8 @@ export class <%= classify(name) %>Component implements OnInit, AfterViewInit<% i
 
     <% if (options.enableRemoteDataHandling || options.hasSearchBar ) { %>
         ngOnDestroy() {
-            <% if (options.hasSearchBar) { %>
-                this.filterService.searchString.setValue('');
+            <% if (options.hasSearchBar || options.isEnumQuickFilter || options.isDateQuickFilter) { %>
+                this.filterService.reset();
             <% } %>
 
             this.destroy$.next();

--- a/src/ng-generate/components/shared/generators/services/filter/files/__name@dasherize__-filter.service.ts.template
+++ b/src/ng-generate/components/shared/generators/services/filter/files/__name@dasherize__-filter.service.ts.template
@@ -174,6 +174,14 @@ export class <%= classify(name) %>FilterService {
     <% } %>
 
     <% if (options.hasSearchBar || options.isEnumQuickFilter || options.isDateQuickFilter) { %>
+        reset(): void {
+            const appliedFilters = [...this.activeFilters];
+
+            appliedFilters.forEach((filter) => {
+                this.resetFilter(filter)
+            })
+        }
+
         /** Removes a specific filter. */
         removeFilter(filter:FilterType) {
             switch(filter.type) {

--- a/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.ts.template
+++ b/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.ts.template
@@ -307,7 +307,9 @@ export class <%= classify(name) %>Component implements OnInit, AfterViewInit, Af
 
     <% if (options.hasSearchBar || options.enableRemoteDataHandling) { %>
         ngOnDestroy(): void {
-            <% if (options.hasSearchBar) { %>this.filterService.searchString.setValue('');<% } %>
+            <% if (options.hasSearchBar || options.isEnumQuickFilter || options.isDateQuickFilter) { %>
+                this.filterService.reset();
+            <% } %>
             this.ngUnsubscribe.next();
             this.ngUnsubscribe.complete();
         }


### PR DESCRIPTION
## Description

A component command bar reset applied filters on destroying the table or card component to prevent sharing the command bar state with other component instances.

Fixes #63 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works