### PR TITLE
Remove semantic explanation from table cells for plain fields

### DIFF
--- a/src/ng-generate/components/shared/generators/constants/semantic-explanation/index.ts
+++ b/src/ng-generate/components/shared/generators/constants/semantic-explanation/index.ts
@@ -11,17 +11,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {
-    apply,
-    applyTemplates,
-    MergeStrategy,
-    mergeWith,
-    move,
-    Rule,
-    SchematicContext,
-    Tree,
-    url
-} from '@angular-devkit/schematics';
+import {apply, applyTemplates, MergeStrategy, mergeWith, move, Rule, SchematicContext, Tree, url} from '@angular-devkit/schematics';
 import {strings} from '@angular-devkit/core';
 import {Values} from '../../../schema';
 import {getTableColumValues} from '../../../utils';
@@ -33,15 +23,15 @@ export function generateSemanticExplanation(options: Values): Rule {
                 applyTemplates({
                     classify: strings.classify,
                     dasherize: strings.dasherize,
-                    options: {...options,
-                        tableColumns: getTableColumValues(options.listAllProperties, options)
+                    options: {
+                        ...options,
+                        tableColumns: getTableColumValues(options.listAllProperties, options),
                     },
-                    name: options.name
+                    name: options.name,
                 }),
-                move('src/app/shared/constants')
+                move('src/app/shared/constants'),
             ]),
-            options.overwrite ? MergeStrategy.Overwrite : MergeStrategy.Error,
+            options.overwrite ? MergeStrategy.Overwrite : MergeStrategy.Error
         );
     };
-
 }

--- a/src/ng-generate/components/shared/methods/generation/extended-table.html.template
+++ b/src/ng-generate/components/shared/methods/generation/extended-table.html.template
@@ -80,7 +80,9 @@
                         <% } else { %>
                             <esmf-table-cell
                                 [value]="<%= cellContent %>"
-                                [description]="'<%= propertyLocaleKeyPath %>.description' | transloco"
+                                <% if(value.isEnumeration) { %>
+                                    [description]="'<%= propertyLocaleKeyPath %>.description' | transloco"
+                                <% } %>
                                 <% if(options.hasSearchBar) { %>
                                     [configs]="configs"
                                     [highlightString]="highlightString"

--- a/src/ng-generate/components/shared/utils.ts
+++ b/src/ng-generate/components/shared/utils.ts
@@ -107,21 +107,28 @@ function generateKey(name: string): string {
  */
 export function getTableColumValues(
     allProps: Array<Property>,
-    options: Schema,
+    options: Schema
 ): Array<{
     property: Property;
     index: number;
     complexPrefix: string;
+    isEnumeration: boolean;
 }> {
     return allProps.flatMap((property: Property, index: number) => {
+        const isEnumeration = property.characteristic && property.characteristic instanceof DefaultEnumeration;
         if (property.effectiveDataType?.isComplex && property.characteristic instanceof DefaultSingleEntity) {
             const complexPropObj = options.templateHelper.getComplexProperties(property, options);
             return complexPropObj.properties.map((complexProp: Property, index: number) => {
-                return {property: complexProp, index: index, complexPrefix: `${complexPropObj.complexProp}.`};
+                return {
+                    property: complexProp,
+                    index: index,
+                    complexPrefix: `${complexPropObj.complexProp}.`,
+                    isEnumeration,
+                };
             });
         }
 
-        return [{property: property, index: index, complexPrefix: ''}];
+        return [{property: property, index: index, complexPrefix: '', isEnumeration}];
     });
 }
 
@@ -168,11 +175,11 @@ export function getCustomRowActions(options: any): string {
               const formattedAction = action.replace(/\.[^/.]+$/, '');
               const formattedActionKebab = formattedAction.replace(/\s+/g, '-').toLowerCase();
               const commonParts = `data-test="custom-action-icon" *ngIf="is${classify(
-                  formattedActionKebab,
+                  formattedActionKebab
               )}Visible" (click)="executeCustomAction($event, '${formattedActionKebab}', row)" style="cursor: pointer;" matTooltip="{{ '${options.templateHelper.getVersionedAccessPrefix(
-                  options,
+                  options
               )}${formattedActionKebab}.customRowAction' | transloco }}" aria-hidden="false" attr.aria-label="{{ '${options.templateHelper.getVersionedAccessPrefix(
-                  options,
+                  options
               )}${formattedActionKebab}.customRowAction' | transloco }}"`;
               return `${action.lastIndexOf('.') > -1 ? `<mat-icon svgIcon="${formattedAction}" ${commonParts}></mat-icon>` : ''}${
                   action.lastIndexOf('.') === -1 ? `<mat-icon ${commonParts} class="material-icons">${action}</mat-icon>` : ''
@@ -246,7 +253,7 @@ export function resolveJsPropertyType(property: Property): string {
         if (property.characteristic.elementCharacteristic) {
             return resolveJsCharacteristicType(
                 property.characteristic.elementCharacteristic,
-                property.characteristic.elementCharacteristic.dataType,
+                property.characteristic.elementCharacteristic.dataType
             );
         }
 


### PR DESCRIPTION
## Description

The PR removes semantic explanation from table cells for plain fields (it's already provided in table header)

Fixes https://github.com/eclipse-esmf/esmf-sdk-js-schematics/issues/126

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

__
