### PR TITLE
Provide table tooltip related styles globally

### DIFF
--- a/src/ng-generate/components/shared/generators/styles/general/files/__name@dasherize__.component.scss.template
+++ b/src/ng-generate/components/shared/generators/styles/general/files/__name@dasherize__.component.scss.template
@@ -269,4 +269,13 @@ $gray-300: #e0e0e0;
   max-width: max-content !important;
 }
 
+.table-cell-tooltip,
+.table-column-tooltip {
+  max-height: none;
+
+  .mat-mdc-tooltip-surface.mdc-tooltip__surface {
+    display: block;
+  }
+}
+
 <%= customStyleImports %>

--- a/src/ng-generate/components/table/generators/components/table-cell/files/__name@dasherize__.component.scss.template
+++ b/src/ng-generate/components/table/generators/components/table-cell/files/__name@dasherize__.component.scss.template
@@ -16,11 +16,3 @@ mat-icon {
   line-height: 1rem;
   height: 1rem;
 }
-
-::ng-deep .table-cell-tooltip {
-  max-height: none;
-
-  .mdc-tooltip__surface {
-    display: block;
-  }
-}

--- a/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.scss.template
+++ b/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.scss.template
@@ -1,14 +1,6 @@
 /** <%= options.generationDisclaimerText %> **/
 @import 'general.component';
 
-::ng-deep .table-column-tooltip {
-  max-height: none;
-
-  .mdc-tooltip__surface {
-    display: block;
-  }
-}
-
 .table-header-icon {
   margin-left: 0.5rem;
   cursor: default;


### PR DESCRIPTION
## Description

The PR provides table tooltip related styles globally and removes `::ng-deep` for those rules.

Fixes https://github.com/eclipse-esmf/esmf-sdk-js-schematics/issues/128

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

__
