### PR TITLE
Do not show cell copy icon when the value is empty

### DIFF
--- a/src/ng-generate/components/table/generators/components/table-cell/files/__name@dasherize__.component.html.template
+++ b/src/ng-generate/components/table/generators/components/table-cell/files/__name@dasherize__.component.html.template
@@ -13,7 +13,7 @@
 <div>
   <mat-icon
     (click)="copyToClipboard(value, $event)"
-    *ngIf="!(value === null || value === undefined)"
+    *ngIf="notEmptyValue"
     class="material-icons copy-to-clipboard"
     data-test="copy-to-clipboard-icon"
   >

--- a/src/ng-generate/components/table/generators/components/table-cell/files/__name@dasherize__.component.ts.template
+++ b/src/ng-generate/components/table/generators/components/table-cell/files/__name@dasherize__.component.ts.template
@@ -24,6 +24,10 @@ export class EsmfTableCellComponent {
     return this.configs.find((config: Config) => config.name.includes('highlight'))?.selected;
   }
 
+  get notEmptyValue(): boolean {
+    return this.value !== null && this.value !== undefined && this.value.trim() !== '-';
+  }
+
   constructor(private readonly clipboard: Clipboard) {}
 
   copyToClipboard(value: any, event: MouseEvent): void {


### PR DESCRIPTION
## Description

Hide "Copy To Clipboard" cell icon whwn the cell value is empty or "-"