### PR TITLE
Table-cell component fails when a cell value is not a string

### DIFF
--- a/src/ng-generate/components/table/generators/components/table-cell/files/__name@dasherize__.component.ts.template
+++ b/src/ng-generate/components/table/generators/components/table-cell/files/__name@dasherize__.component.ts.template
@@ -25,7 +25,7 @@ export class EsmfTableCellComponent {
   }
 
   get notEmptyValue(): boolean {
-    return this.value !== null && this.value !== undefined && this.value.trim() !== '-';
+    return this.value !== null && this.value !== undefined && this.value.toString().trim() !== '-';
   }
 
   constructor(private readonly clipboard: Clipboard) {}


### PR DESCRIPTION
## Description

Table-cell component fails when a cell value is not a string. Sometimes the value is array

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)