### PR TITLE
Replace deprecated @import with @use keyword

### DIFF
--- a/src/ng-generate/components/card/generators/components/card/files/__name@dasherize__.component.scss.template
+++ b/src/ng-generate/components/card/generators/components/card/files/__name@dasherize__.component.scss.template
@@ -1,5 +1,5 @@
 /** <%= options.generationDisclaimerText %> **/
-@import 'general.component';
+@use 'general.component' as *;
 
 .data-card {
   margin: 15px 0 10px 0;

--- a/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.scss.template
+++ b/src/ng-generate/components/table/generators/components/table/files/__name@dasherize__.component.scss.template
@@ -1,5 +1,5 @@
 /** <%= options.generationDisclaimerText %> **/
-@import 'general.component';
+@use 'general.component' as *;
 
 .table-header-icon {
   margin-left: 0.5rem;


### PR DESCRIPTION
## Description

Sass `@import` rules are deprecated and will be removed in Dart Sass 3.0.0. So the solution is to follow Sass recommendations and use `@use` rules instead

Fixes #135 

## Type of change

Please delete options that are not relevant.

- [x] Resolve deprecation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
